### PR TITLE
Add gitignore and setup.py files and do a model training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Byte-compiled / optimized / DLL files
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+################################################################################
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from setuptools import setup, find_packages
+
+
+###############################################################################
+# Pure python packages
+###############################################################################
+packages = find_packages()
+
+setup(
+    name='self_supervision_benchmark',
+    packages=packages,
+)


### PR DESCRIPTION
successfully did a run on my devgpu with the installation and in1k finetuning

**Installation:**
```
1. install anaconda https://fburl.com/5ap1489m  
2. export PATH=/home/prigoyal/local/anaconda3/bin:$PATH    OR module load on devfair
3. conda create --name ssl-benchmark python=3.6
4. source activate ssl-benchmark
5. conda install -c pytorch pytorch
6. conda install -yq future protobuf pyyaml six scipy pycurl opencv scikit-learn cython networkx
7. test: python -c 'from caffe2.python import core, workspace, caffe2_pb2, scope'
8. COCO API installation: 
    - conda install -c conda-forge matplotlib cycler
    - git clone https://github.com/cocodataset/cocoapi.git ~/local/cocoapi
    - cd ~/local/cocoapi/PythonAPI/
    - with-proxy python setup.py build_ext install
    - test: cd ~ && python -c 'from pycocotools.coco import COCO'
9. python setup.py install
```

**Run:**
```
python tools/train_net.py --config_file configs/legacy_tasks/imagenet_linear_tune/caffenet_bvlc_random_finetune_linear.yaml TRAIN.DATA_FILE /mnt/vol/gfsai-east/ai-group/users/prigoyal/caffe2/resnet/gen/in1k_disk/train_images.npy TRAIN.LABELS_FILE /mnt/vol/gfsai-east/ai-group/users/prigoyal/caffe2/resnet/gen/in1k_disk/train_labels.npy TEST.DATA_FILE /mnt/vol/gfsai-east/ai-group/users/prigoyal/caffe2/resnet/gen/in1k_disk/val_images.npy TEST.LABELS_FILE /mnt/vol/gfsai-east/ai-group/users/prigoyal/caffe2/resnet/gen/in1k_disk/val_labels.npy
```